### PR TITLE
[feature] EntityNotFound 예외 처리

### DIFF
--- a/src/main/java/com/everysesac/backend/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/everysesac/backend/domain/post/service/PostServiceImpl.java
@@ -36,10 +36,11 @@ public class PostServiceImpl implements PostService{
     @Override
     public PostResponseDTO modify(PostUpdateRequestDTO postCreateRequestDTO, Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow();
+                .orElseThrow(()->new EntityNotFoundException("Invalid request parameters : "+postId));
         post.changeTitle(postCreateRequestDTO.getTitle());
         post.changeContent(postCreateRequestDTO.getContent());
         post.changePostStatus(postCreateRequestDTO.getPostStatus());
+
         return modelMapper.map(post, PostResponseDTO.class);
     }
 
@@ -47,7 +48,7 @@ public class PostServiceImpl implements PostService{
     public void softDelete(Long postId) {
         long updatedRows = postQueryRepository.softDelete(postId);
         if (updatedRows == 0) { // 변경된 데이터 수가 0일 때 예외처리
-            throw new EntityNotFoundException("post not found : "+postId);
+            throw new EntityNotFoundException("Invalid request parameters : "+postId);
         }
     }
 

--- a/src/main/java/com/everysesac/backend/global/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/everysesac/backend/global/exception/advice/GlobalExceptionHandler.java
@@ -60,7 +60,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(EntityNotFoundException ex) {
         log.info("EntityNotFoundException",ex);
-        ErrorResponse response = new ErrorResponse("Bad Request", ErrorCode.INVALID_REQUEST_PARAMETER.getCode(), ErrorCode.INVALID_REQUEST_PARAMETER.getMessage(), null);
+        ErrorResponse response = new ErrorResponse("error", ErrorCode.INVALID_REQUEST_PARAMETER.getCode(), ErrorCode.INVALID_REQUEST_PARAMETER.getMessage(), null);
         return ResponseEntity.status(ErrorCode.INVALID_REQUEST_PARAMETER.getStatus()).
                 body(response);
     }

--- a/src/main/java/com/everysesac/backend/global/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/everysesac/backend/global/exception/advice/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package com.everysesac.backend.global.exception.advice;
 
 import com.everysesac.backend.global.exception.ErrorCode;
 import com.everysesac.backend.global.exception.ErrorResponse;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -51,5 +53,15 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
                 .body(response);
+    }
+
+    // EntityNotFoundException 처리하는 메서드
+    // 존재하지 않는 postId를 요청했을때 INVALID_REQUEST_PARAMETER(E4001)으로 처리
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(EntityNotFoundException ex) {
+        log.info("EntityNotFoundException",ex);
+        ErrorResponse response = new ErrorResponse("Bad Request", ErrorCode.INVALID_REQUEST_PARAMETER.getCode(), ErrorCode.INVALID_REQUEST_PARAMETER.getMessage(), null);
+        return ResponseEntity.status(ErrorCode.INVALID_REQUEST_PARAMETER.getStatus()).
+                body(response);
     }
 }


### PR DESCRIPTION
#10

PR 타입

- 기능 추가


반영 브랜치

- exception/entitynotfound-> feature


변경 사항

- EntityNotFoundException이 발생하면 HttpStatus.BAD_REQUEST로 처리됩니다.
   (ErrorCode INVALID_REQUEST_PARAMETER("E4001", "Invalid request parameters.", HttpStatus.BAD_REQUEST))
- 서비스 레이어의 예외처리를 EntityNotFoundException으로 통일